### PR TITLE
カテゴリー一覧ページに登録されているデータの表示

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -7,7 +7,7 @@ class CategoriesController < ApplicationController
 
   def show
     @items = @category.set_items
-    @items = @items.where(buyer_id: nil).order("created_at DESC").page(params[:page]).per(9)
+    @items = @items.order("created_at DESC").page(params[:page]).per(9)
   end
 
   private

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -9,9 +9,9 @@
     .title
       = "#{@category.name}の商品一覧"
       .title__border
-    -# - if @items
-    -#   %ul.lists
-    -#     = render "items/item-lists", items: @items
-    -# = paginate @items
+    - if @items
+      %ul.lists
+        = render "items/item-lists", items: @items
+    = paginate @items
 .footer
   =render "/posts/footer"

--- a/app/views/items/_item-lists.html.haml
+++ b/app/views/items/_item-lists.html.haml
@@ -2,21 +2,22 @@
   .items_lists__main__list
     .container
       - items.each do |item|
-        .container__box
-          = link_to items_path(id: item.id) do
-            - ft_image = item.images.first
-            = image_tag ft_image.image.url, class: "list__image"
-            .list__main
-              .list__main__name
-                = item.name
-              .list__main__details
-                %ul
-                  %li 
-                    = "数量"
-                    = item.quantity
-                    = "ヶ"
-                  %li
-                    = "購入店舗"
-                    = item.shop
-                  %li
-                    = "消費期限"
+        - if current_user.id == item.user_id
+          .container__box
+            = link_to items_path(id: item.id) do
+              - ft_image = item.images.first
+              = image_tag ft_image.image.url, class: "list__image"
+              .list__main
+                .list__main__name
+                  = item.name
+                .list__main__details
+                  %ul
+                    %li 
+                      = "数量"
+                      = item.quantity
+                      = "ヶ"
+                    %li
+                      = "購入店舗"
+                      = item.shop
+                    %li
+                      = "消費期限"

--- a/app/views/items/_item-lists.html.haml
+++ b/app/views/items/_item-lists.html.haml
@@ -1,9 +1,9 @@
 .items_lists__main
   .items_lists__main__list
     .container
-      - @parents.each do |parent|
+      - items.each do |item|
         .container__box
-          = link_to item_path(id: item.id) do
+          = link_to items_path(id: item.id) do
             - ft_image = item.images.first
             = image_tag ft_image.image.url, class: "list__image"
             .list__main

--- a/app/views/items/_item-lists.html.haml
+++ b/app/views/items/_item-lists.html.haml
@@ -4,7 +4,7 @@
       - items.each do |item|
         - if current_user.id == item.user_id
           .container__box
-            = link_to items_path(id: item.id) do
+            = link_to item_path(item.id), method: :get do
               - ft_image = item.images.first
               = image_tag ft_image.image.url, class: "list__image"
               .list__main

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -68,8 +68,8 @@
         = render "comment"
       .links
         %li
-          = link_to "< 親カテゴリーに戻る",'/#'
+          = link_to "< トップに戻る", root_path
         %li
-          = link_to "商品一覧に戻る >",'/#'
+          = link_to "カテゴリー一覧に戻る >", categories_path
   .items__footer
     = render "/posts/footer"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -17,7 +17,7 @@
           = link_to new_item_path, method: :get do
             商品を登録する
         .mypage__main__btns__product__right
-          = link_to "登録品一覧","/users"
+          = link_to "登録品一覧", categories_path
       .mypage__main__btns__myuser
         .mypage__main__btns__myuser__left
           = link_to "メールアドレスの変更", '/#/'


### PR DESCRIPTION
[what]
・カテゴリー一覧ページに登録された商品を表示
・カテゴリー一覧ページにおいて登録された商品は自身が登録した物しか表示されない
(他のユーザーから見られる事がない)
・カテゴリー一覧ページにおいて登録された商品をクリックすると詳細ページに遷移できる
・詳細ページからトップページ、カテゴリー一覧ページに遷移できるようにリンクを設置
[why]
・他のユーザーから見られる事がないのでプライバシーの保護になる
・利便性の向上