### PR TITLE
アドレス指定によるページ遷移編集

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,4 +5,10 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
   end
+
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+
+  def render_404
+    redirect_to root_path
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,8 +22,12 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @comment = Comment.new
-    @comments = @item.comments.includes(:user)
+    if user_signed_in? && current_user.id == @item.user_id
+      @comment = Comment.new
+      @comments = @item.comments.includes(:user)
+    else
+      redirect_to root_path
+    end
   end
 
   def search
@@ -39,14 +43,18 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @grandchild = Category.find(@item.category_id)
-    @child = @grandchild.parent
-    @parent = @child.parent
+    if user_signed_in? && current_user.id == @item.user_id
+      @grandchild = Category.find(@item.category_id)
+      @child = @grandchild.parent
+      @parent = @child.parent
+    else
+      redirect_to root_path
+    end
   end
 
   def update
     if @item.update!(item_params)
-      redirect_to root_path, notice: '登録内容を編集しました'
+      redirect_to "/users/#{current_user.id}"
     else
       render "edit"
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,10 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @item = Item.all
-  end  
+    if @user == current_user
+      @item = Item.all
+    else
+      redirect_to root_path
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
 
   root to: 'posts#index'
-  
+
   resources :posts, only: [:index]
   resources :users, only: [:index, :show]
   resources :categories, only: [:index, :show]


### PR DESCRIPTION
[what]
・存在しないアドレスへのアクセスがあった場合にroot_pathを設定
・他のユーザーが登録したデータの詳細及び編集画面にアドレスで指定した場合に、root_pathでトップページに遷移させるように設定
・自身以外のユーザーのマイページにアドレスを指定してアクセスしようとした場合にroot_pathを設定
・登録情報を編集後の遷移先を変更

[why]
・ユーザーの登録情報の保護の為